### PR TITLE
Add ECG dataset utilities and EF head

### DIFF
--- a/dataset/build_ecg_dataset.py
+++ b/dataset/build_ecg_dataset.py
@@ -1,0 +1,86 @@
+import os
+import csv
+import math
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, Dataset
+from ecg_patch_embed import ECGPatchEmbed
+
+
+class _RawECG(Dataset):
+    def __init__(self, csv_path: str):
+        rows = [r for r in csv.DictReader(open(csv_path))]
+        self.items = [
+            (r["path"], float(r["ef"]), int(r["ef_bin"])) for r in rows
+        ]
+
+    def __len__(self) -> int:
+        return len(self.items)
+
+    def __getitem__(self, i: int):
+        p, ef, efb = self.items[i]
+        x = np.load(p)  # [C,T], T≈2500 for 10s
+        return (
+            torch.from_numpy(x).float(),
+            torch.tensor(ef).float(),
+            torch.tensor(efb).long(),
+        )
+
+
+def build_shards(
+    csv_path: str,
+    out_dir: str,
+    shard_size: int = 10000,
+    in_ch: int = 12,
+    d: int = 256,
+):
+    os.makedirs(out_dir, exist_ok=True)
+    ds = _RawECG(csv_path)
+    dl = DataLoader(ds, batch_size=64, shuffle=False, num_workers=4)
+    embed = ECGPatchEmbed(in_ch=in_ch, d=d).eval()
+    with torch.no_grad():
+        buf_tokens, buf_masks, buf_efo, buf_efr = [], [], [], []
+        sid = 0
+        n = 0
+        for xb, efr, efo in dl:
+            xb = xb  # CPU OK; switch to cuda() if large
+            tokens = embed(xb).cpu()  # [B,N,d]
+            B, N, D = tokens.shape
+            mask = torch.zeros(B, N, dtype=torch.bool)
+            buf_tokens.append(tokens.numpy())
+            buf_masks.append(mask.numpy())
+            buf_efo.append(efo.numpy())
+            buf_efr.append(efr.numpy())
+            n += B
+            if n >= shard_size:
+                np.savez_compressed(
+                    os.path.join(out_dir, f"ecg_{sid:05d}.npz"),
+                    tokens=np.concatenate(buf_tokens, 0),
+                    mask=np.concatenate(buf_masks, 0),
+                    label_ord=np.concatenate(buf_efo, 0),
+                    label_reg=np.concatenate(buf_efr, 0),
+                )
+                sid += 1
+                n = 0
+                buf_tokens, buf_masks, buf_efo, buf_efr = [], [], [], []
+        if n > 0:
+            np.savez_compressed(
+                os.path.join(out_dir, f"ecg_{sid:05d}.npz"),
+                tokens=np.concatenate(buf_tokens, 0),
+                mask=np.concatenate(buf_masks, 0),
+                label_ord=np.concatenate(buf_efo, 0),
+                label_reg=np.concatenate(buf_efr, 0),
+            )
+
+
+if __name__ == "__main__":
+    import argparse
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--csv", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--in_ch", type=int, default=12)
+    ap.add_argument("--d", type=int, default=256)
+    ap.add_argument("--shard_size", type=int, default=10000)
+    args = ap.parse_args()
+    build_shards(args.csv, args.out, args.shard_size, args.in_ch, args.d)

--- a/dataset/ecg_patch_embed.py
+++ b/dataset/ecg_patch_embed.py
@@ -1,0 +1,19 @@
+import torch
+import torch.nn as nn
+
+
+class ECGPatchEmbed(nn.Module):
+    def __init__(self, in_ch: int = 12, d: int = 256):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Conv1d(in_ch, 64, 7, 2, 3),
+            nn.ReLU(),
+            nn.Conv1d(64, 128, 5, 2, 2),
+            nn.ReLU(),
+            nn.Conv1d(128, d, 3, 2, 1),
+            nn.ReLU(),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # x: [B,C,T]
+        z = self.net(x)  # [B,d,T']
+        return z.transpose(1, 2)  # [B,N(=T'),d]

--- a/ecg_dataset.py
+++ b/ecg_dataset.py
@@ -1,0 +1,31 @@
+import os
+import glob
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+
+class ECGShardDataset(Dataset):
+    def __init__(self, root: str):
+        self.files = sorted(glob.glob(os.path.join(root, "*.npz")))
+        self.idx = []
+        for si, f in enumerate(self.files):
+            n = np.load(f)["label_ord"].shape[0]
+            self.idx += [(si, i) for i in range(n)]
+
+    def __len__(self) -> int:
+        return len(self.idx)
+
+    def __getitem__(self, i: int):
+        si, ri = self.idx[i]
+        with np.load(self.files[si]) as z:
+            tokens = torch.from_numpy(z["tokens"][ri])  # [N,d]
+            mask = torch.from_numpy(z["mask"][ri])  # [N]
+            yb = torch.tensor(int(z["label_ord"][ri]))
+            yr = torch.tensor(float(z["label_reg"][ri]))
+        return {
+            "tokens": tokens.float(),
+            "mask": mask.bool(),
+            "label_ord": yb,
+            "label_reg": yr,
+        }

--- a/hrm/__init__.py
+++ b/hrm/__init__.py
@@ -1,0 +1,1 @@
+# HRM extension package for ECG dataset and EF head.

--- a/hrm/configs/ecg_ef.yaml
+++ b/hrm/configs/ecg_ef.yaml
@@ -1,0 +1,25 @@
+task: ecg_ef
+dataset:
+  name: ecg
+  train_root: /data/ecg/shards/train
+  val_root: /data/ecg/shards/val
+model:
+  d_model: 256
+  nhead: 8
+  d_ff: 1024
+  nlayers_low: 2
+  nlayers_high: 1
+  M: 3
+  T_low: 2
+  head: ef
+  bins: [35,40,50]
+train:
+  batch_size: 32
+  epochs: 30
+  lr: 1e-3
+  weight_decay: 1e-4
+  deep_supervision: true
+  monotonicity_margin: 0.0
+  use_act: false
+eval:
+  metrics: [auroc_bin0,auroc_bin1,auprc_bin0,mae_reg]

--- a/hrm/models/heads/ef_head.py
+++ b/hrm/models/heads/ef_head.py
@@ -1,0 +1,37 @@
+import torch
+import torch.nn as nn
+
+
+def coral_targets(yb: torch.Tensor, K: int = 4) -> torch.Tensor:
+    B = yb.size(0)
+    t = torch.arange(K - 1, device=yb.device).unsqueeze(0).expand(B, -1)
+    return (yb.unsqueeze(1) > t).float()
+
+
+class EFHead(nn.Module):
+    def __init__(self, d: int, K: int = 4):
+        super().__init__()
+        self.ord = nn.Linear(d, K - 1)
+        self.reg = nn.Linear(d, 1)
+
+    def forward(self, h: torch.Tensor):  # h: [B,d] (H-state)
+        return self.ord(h), self.reg(h).squeeze(-1)
+
+
+class EFLoss(nn.Module):
+    def __init__(self, K: int = 4, mono_margin: float = 0.0):
+        super().__init__()
+        self.K = K
+        self.bce = nn.BCEWithLogitsLoss()
+        self.hub = nn.SmoothL1Loss()
+        self.m = mono_margin
+
+    def forward(self, ord_logits_list, reg_list, yb, yr):
+        yord = coral_targets(yb, self.K)
+        stage = []
+        for ol, rg in zip(ord_logits_list, reg_list):
+            stage.append(self.bce(ol, yord) + self.hub(rg, yr))
+        mono = 0.0
+        for i in range(1, len(stage)):
+            mono = mono + torch.clamp(stage[i - 1] - stage[i] - self.m, min=0.0)
+        return sum(stage) + mono

--- a/hrm/tasks/__init__.py
+++ b/hrm/tasks/__init__.py
@@ -1,0 +1,1 @@
+# Intentionally left minimal for task registrations if needed.

--- a/hrm/tasks/ecg_ef.py
+++ b/hrm/tasks/ecg_ef.py
@@ -1,0 +1,20 @@
+import torch
+from ..models.heads.ef_head import EFHead, EFLoss
+
+
+class ECG_EF_Task:
+    def __init__(self, d_model: int, bins, mono_margin: float = 0.0):
+        self.head = EFHead(d_model, K=len(bins) + 1)
+        self.loss = EFLoss(K=len(bins) + 1, mono_margin=mono_margin)
+
+    def forward(self, H_states):  # list of [B,d] per cycle
+        ords, regs = [], []
+        for h in H_states:
+            o, r = self.head(h)
+            ords.append(o)
+            regs.append(r)
+        return ords, regs
+
+    def compute_loss(self, outs, batch):
+        ords, regs = outs
+        return self.loss(ords, regs, batch["label_ord"], batch["label_reg"])


### PR DESCRIPTION
## Summary
- add 1D conv ECG patch embed and offline shard builder
- load ECG shards and predict ejection fraction with new EF head and loss
- provide example config and task glue for training
- move ECG dataset scripts to dataset folder to match project layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b8cb87b70832a9d7d720f3bdb13c2